### PR TITLE
change bcoin and coin type to double

### DIFF
--- a/biz/user/src/commonMain/composeResources/values-zh/strings.xml
+++ b/biz/user/src/commonMain/composeResources/values-zh/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="b_coin">B币: %1$d</string>
-    <string name="coin">硬币: %1$d</string>
+    <string name="b_coin">B币: %1$.2f</string>
+    <string name="coin">硬币: %1$.2f</string>
     <string name="dynamic">动态</string>
     <string name="follow">关注</string>
     <string name="fans">粉丝</string>

--- a/biz/user/src/commonMain/composeResources/values/strings.xml
+++ b/biz/user/src/commonMain/composeResources/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="b_coin">BCoin: %1$d</string>
-    <string name="coin">Coin: %1$d</string>
+    <string name="b_coin">BCoin: %1$.2f</string>
+    <string name="coin">Coin: %1$.2f</string>
     <string name="dynamic">dynamic</string>
     <string name="follow">follow</string>
     <string name="fans">fans</string>

--- a/biz/user/src/commonMain/kotlin/top/suzhelan/bili/biz/user/entity/mine/Mine.kt
+++ b/biz/user/src/commonMain/kotlin/top/suzhelan/bili/biz/user/entity/mine/Mine.kt
@@ -13,9 +13,9 @@ data class Mine(
 //    @SerialName("achievement") val achievement: Achievement, // 用户成就
 //    @SerialName("audio_type") val audioType: Int, // 音频类型
 //    @SerialName("avatar") val avatar: Avatar, // 用户头像
-    @SerialName("bcoin") val bcoin: Int, // B币数量
+    @SerialName("bcoin") val bcoin: Double, // B币数量
 //    @SerialName("bubbles") val bubbles: Unknown?, // 气泡
-    @SerialName("coin") val coin: Int, // 硬币数量
+    @SerialName("coin") val coin: Double, // 硬币数量
     @SerialName("dynamic") val dynamic: Int, // 动态数量
     @SerialName("enable_bili_link") val enableBiliLink: Boolean, // 是否启用B站链接
     @SerialName("face") val face: String, // 用户头像URL


### PR DESCRIPTION
## What
Fix JSON deserialization crash in user profile page by updating `coin/bcoin` field types from `Int` to `Double`

## Why
API returns floating-point values (e.g., "coin":1145.1) causing `JsonConvertException` and blank user page

## Where
`Mine.kt` entity class and string resource files for proper decimal formatting