### PR TITLE
feat(player): support portrait video fullscreen handling

### DIFF
--- a/shared/player/src/androidMain/kotlin/top/suzhelan/bili/player/controller/PlayerSyncController.android.kt
+++ b/shared/player/src/androidMain/kotlin/top/suzhelan/bili/player/controller/PlayerSyncController.android.kt
@@ -56,7 +56,8 @@ actual object PlayerMediaDataUtils {
     actual fun doLoadMediaData(
         mediampPlayer: MediampPlayer,
         videoUrl: String,
-        audioUrl: String
+        audioUrl: String,
+        onVideoSizeChanged: ((width: Int, height: Int) -> Unit)?
     ) {
         val exoPlayer = mediampPlayer.impl as ExoPlayer
         val videoSource = AndroidPlayerParam.buildMediaSource(videoUrl)
@@ -72,16 +73,27 @@ actual object PlayerMediaDataUtils {
                         title = "",
                         durationMillis = duration,
                     )
+
+                    onVideoSizeChanged?.invoke(videoSize.width, videoSize.height)
                 }
             })
         }
     }
 
-    actual fun setFullScreen(context: BiliContext, fullScreen: Boolean) {
+    actual fun setFullScreen(context: BiliContext, fullScreen: Boolean, isPortraitVideo: Boolean) {
         if (context is Activity) {
             if (fullScreen) {
-                //切换到横屏
-                context.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+                // 根据传入的视频比例信息决定屏幕方向
+
+                // 根据视频类型选择合适的屏幕方向
+                if (isPortraitVideo) {
+                    // 竖屏视频：保持竖屏方向，不做横屏切换
+                    context.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+                } else {
+                    // 横屏视频：切换到横屏
+                    context.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+                }
+
                 //屏幕常亮
                 context.window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
                 // 使用 WindowInsetsController 隐藏系统 UI（推荐方式）

--- a/shared/player/src/commonMain/kotlin/top/suzhelan/bili/player/controller/PlayerSyncController.kt
+++ b/shared/player/src/commonMain/kotlin/top/suzhelan/bili/player/controller/PlayerSyncController.kt
@@ -37,6 +37,21 @@ class PlayerSyncController(
 
     var isFillMaxSize by mutableStateOf(false)
 
+    // 视频尺寸信息
+    var videoWidth by mutableStateOf(0)
+        private set
+
+    var videoHeight by mutableStateOf(0)
+        private set
+
+    // 视频宽高比
+    val videoAspectRatio: Float get() = if (videoWidth > 0 && videoHeight > 0) {
+        videoWidth.toFloat() / videoHeight.toFloat()
+    } else 0f
+
+    // 判断是否为竖屏视频（宽高比小于1）
+    val isPortraitVideo: Boolean get() = videoAspectRatio < 1f
+
     val playbackState: StateFlow<PlaybackState> get() = videoPlayer.playbackState
 
     val isPlaying: Boolean get() = videoPlayer.playbackState.value.isPlaying
@@ -72,7 +87,14 @@ class PlayerSyncController(
      * 播放视频
      */
     fun play(videoUrl: String, audioUrl: String) {
-        PlayerMediaDataUtils.doLoadMediaData(videoPlayer, videoUrl, audioUrl)
+        PlayerMediaDataUtils.doLoadMediaData(
+            videoPlayer,
+            videoUrl,
+            audioUrl,
+            onVideoSizeChanged = { width, height ->
+                updateVideoSize(width, height)
+            }
+        )
     }
 
     /**
@@ -127,6 +149,14 @@ class PlayerSyncController(
         }
     }
 
+    /**
+     * 更新视频尺寸信息
+     */
+    fun updateVideoSize(width: Int, height: Int) {
+        videoWidth = width
+        videoHeight = height
+    }
+
 
     fun reversalFullScreen() {
         isFullScreen = !isFullScreen
@@ -175,10 +205,11 @@ expect object PlayerMediaDataUtils {
     fun doLoadMediaData(
         mediampPlayer: MediampPlayer,
         videoUrl: String,
-        audioUrl: String
+        audioUrl: String,
+        onVideoSizeChanged: ((width: Int, height: Int) -> Unit)? = null
     )
 
-    fun setFullScreen(context: BiliContext, fullScreen: Boolean)
+    fun setFullScreen(context: BiliContext, fullScreen: Boolean, isPortraitVideo: Boolean = false)
 }
 
 

--- a/shared/player/src/commonMain/kotlin/top/suzhelan/bili/player/ui/bottombar/PlayerBottomBar.kt
+++ b/shared/player/src/commonMain/kotlin/top/suzhelan/bili/player/ui/bottombar/PlayerBottomBar.kt
@@ -54,7 +54,7 @@ fun PlayerBottomBar(
     val context by rememberUpdatedState(BiliLocalContext.current)
     //订阅全屏状态
     LaunchedEffect(isFullScreen) {
-        PlayerMediaDataUtils.setFullScreen(context, isFullScreen)
+        PlayerMediaDataUtils.setFullScreen(context, isFullScreen, controller.isPortraitVideo)
     }
     //最左侧 播放/暂时按钮
     IconButton(

--- a/shared/player/src/desktopMain/kotlin/top/suzhelan/bili/player/controller/PlayerSyncController.desktop.kt
+++ b/shared/player/src/desktopMain/kotlin/top/suzhelan/bili/player/controller/PlayerSyncController.desktop.kt
@@ -12,7 +12,8 @@ actual object PlayerMediaDataUtils {
     actual fun doLoadMediaData(
         mediampPlayer: MediampPlayer,
         videoUrl: String,
-        audioUrl: String
+        audioUrl: String,
+        onVideoSizeChanged: ((width: Int, height: Int) -> Unit)?
     ) {
         CoroutineScope(Dispatchers.IO).launch {
            /* mediampPlayer.setMediaData(
@@ -45,6 +46,6 @@ actual object PlayerMediaDataUtils {
         }
     }
 
-    actual fun setFullScreen(context: BiliContext, fullScreen: Boolean) {
+    actual fun setFullScreen(context: BiliContext, fullScreen: Boolean, isPortraitVideo: Boolean) {
     }
 }


### PR DESCRIPTION
## What

适配竖屏视频全屏适配，根据视频宽高比自动选择：
  - 竖屏视频(如9:16)保持竖屏方向直接放大，避免黑边
  - 横屏视频(如16:9)正常旋转至横屏全屏

## Why

原有全屏逻辑对所有视频强制横屏旋转，导致竖屏视频在横屏全屏时两边出现大面积黑边，视频内容被压缩在屏幕中间，用户体验不佳。

## Where

1. `PlayerSyncController.kt`
2. `PlayerSyncController.android.kt`
3. `PlayerBottomBar.kt`

## In The Future

也许可以实现类似竖屏短视频的scroll的视频流？
